### PR TITLE
Add WebAuthn FIDO2 authentication demo with Flask and MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
-# webauthnTest
+# WebAuthn Demo アプリケーション
+
+Flask と MySQL を用いて構築した WebAuthn (FIDO2) ベースのパスワードレス認証デモです。ブラウザが対応していれば、セキュリティキーやプラットフォーム認証器を用いて登録・ログインできます。
+
+## 主な機能
+
+- WebAuthn による FIDO2 認証器の登録とログイン
+- MySQL によるユーザー・認証情報の永続化
+- Bootstrap を利用したシンプルな UI
+- `.env` などからオーバーライド可能な設定
+
+## セットアップ手順
+
+### 1. 依存関係のインストール
+
+```bash
+python -m venv venv
+source venv/bin/activate  # Windows の場合は venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+### 2. MySQL の準備
+
+以下はローカルで MySQL 8.x を利用する例です。
+
+```sql
+CREATE DATABASE webauthn CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE USER 'webauthn'@'localhost' IDENTIFIED BY 'webauthn';
+GRANT ALL PRIVILEGES ON webauthn.* TO 'webauthn'@'localhost';
+FLUSH PRIVILEGES;
+```
+
+接続情報を環境変数で変更する場合は `.env` を作成し、以下のように設定してください。
+
+```dotenv
+DATABASE_URI=mysql+pymysql://<user>:<password>@<host>:<port>/<database>
+SECRET_KEY=ランダムな文字列
+WEBAUTHN_RP_ID=localhost
+WEBAUTHN_ORIGIN=http://localhost:5000
+WEBAUTHN_RP_NAME=WebAuthn Demo
+```
+
+### 3. アプリケーションの起動
+
+```bash
+export FLASK_APP=app:create_app
+flask run --host=0.0.0.0 --port=5000
+```
+
+起動後、ブラウザで `http://localhost:5000` にアクセスして登録・ログインを試してください。
+
+## ディレクトリ構成
+
+```
+.
+├── app.py               # Flask アプリケーション本体
+├── config.py            # 設定
+├── requirements.txt     # 依存パッケージ
+├── templates/           # Jinja2 テンプレート
+└── static/              # CSS / JavaScript
+```
+
+## 注意事項
+
+- WebAuthn を利用するには HTTPS が推奨されます。本番環境では TLS を必ず有効化してください。
+- ブラウザが WebAuthn/FIDO2 に対応していない場合は動作しません。
+- デモ用途のため、詳細なエラーハンドリングや管理機能は最小限です。

--- a/app.py
+++ b/app.py
@@ -1,0 +1,334 @@
+import base64
+import json
+from datetime import datetime
+from typing import List, Optional
+from uuid import uuid4
+
+from flask import (
+    Flask,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.orm import relationship
+
+from config import Config
+
+from webauthn import (
+    generate_authentication_options,
+    generate_registration_options,
+    verify_authentication_response,
+    verify_registration_response,
+)
+from webauthn.helpers.exceptions import InvalidAuthenticationResponse, InvalidRegistrationResponse
+from webauthn.helpers.structs import (
+    AuthenticationCredential,
+    AuthenticatorSelectionCriteria,
+    AuthenticatorTransport,
+    PublicKeyCredentialDescriptor,
+    RegistrationCredential,
+    ResidentKeyRequirement,
+    UserVerificationRequirement,
+)
+
+
+db = SQLAlchemy()
+
+
+class User(db.Model):
+    __tablename__ = "users"
+
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(64), unique=True, nullable=False)
+    display_name = db.Column(db.String(128), nullable=False)
+    user_handle = db.Column(db.LargeBinary(64), unique=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    credentials = relationship("Credential", back_populates="user", cascade="all, delete-orphan")
+
+
+class Credential(db.Model):
+    __tablename__ = "credentials"
+
+    id = db.Column(db.Integer, primary_key=True)
+    credential_id = db.Column(db.String(255), unique=True, nullable=False)
+    public_key = db.Column(db.Text, nullable=False)
+    sign_count = db.Column(db.Integer, default=0)
+    transports = db.Column(db.String(255), nullable=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+
+    user = relationship("User", back_populates="credentials")
+
+
+class ChallengeSession:
+    """Utility helpers for storing and retrieving challenges in the session."""
+
+    challenge_key = "webauthn_challenge"
+    username_key = "pending_username"
+    display_name_key = "pending_display_name"
+    user_handle_key = "pending_user_handle"
+
+    @staticmethod
+    def store(challenge: str, username: str, display_name: str, user_handle: bytes) -> None:
+        session[ChallengeSession.challenge_key] = challenge
+        session[ChallengeSession.username_key] = username
+        session[ChallengeSession.display_name_key] = display_name
+        session[ChallengeSession.user_handle_key] = base64.urlsafe_b64encode(user_handle).decode("utf-8")
+
+    @staticmethod
+    def store_authentication(challenge: str) -> None:
+        session[ChallengeSession.challenge_key] = challenge
+
+    @staticmethod
+    def pop_challenge() -> Optional[str]:
+        return session.pop(ChallengeSession.challenge_key, None)
+
+    @staticmethod
+    def pending_username() -> Optional[str]:
+        return session.get(ChallengeSession.username_key)
+
+    @staticmethod
+    def pending_display_name() -> Optional[str]:
+        return session.get(ChallengeSession.display_name_key)
+
+    @staticmethod
+    def pending_user_handle() -> Optional[bytes]:
+        encoded = session.get(ChallengeSession.user_handle_key)
+        if not encoded:
+            return None
+        return base64.urlsafe_b64decode(encoded.encode("utf-8"))
+
+    @staticmethod
+    def clear_pending_user() -> None:
+        session.pop(ChallengeSession.username_key, None)
+        session.pop(ChallengeSession.display_name_key, None)
+        session.pop(ChallengeSession.user_handle_key, None)
+
+
+def create_app(config_class: type[Config] = Config) -> Flask:
+    app = Flask(__name__)
+    app.config.from_object(config_class)
+    db.init_app(app)
+
+    with app.app_context():
+        db.create_all()
+
+    @app.route("/")
+    def index():
+        if session.get("user_id"):
+            return redirect(url_for("dashboard"))
+        return redirect(url_for("login"))
+
+    @app.route("/register", methods=["GET"])
+    def register_page():
+        return render_template("register.html")
+
+    @app.route("/login", methods=["GET"])
+    def login_page():
+        return render_template("login.html")
+
+    @app.route("/dashboard")
+    def dashboard():
+        user_id = session.get("user_id")
+        if not user_id:
+            return redirect(url_for("login"))
+        user = User.query.get(user_id)
+        return render_template("dashboard.html", user=user)
+
+    @app.route("/logout")
+    def logout():
+        session.clear()
+        return redirect(url_for("login"))
+
+    @app.route("/register/options", methods=["POST"])
+    def register_options():
+        data = request.get_json(force=True)
+        username = data.get("username", "").strip()
+        display_name = data.get("displayName", "").strip()
+        if not username or not display_name:
+            return jsonify({"error": "username と表示名は必須です"}), 400
+
+        user = User.query.filter_by(username=username).first()
+        if user:
+            user_handle = user.user_handle
+            exclude_credentials: List[PublicKeyCredentialDescriptor] = [
+                PublicKeyCredentialDescriptor(
+                    id=base64.urlsafe_b64decode(c.credential_id.encode("utf-8")),
+                    type="public-key",
+                )
+                for c in user.credentials
+            ]
+        else:
+            user_handle = uuid4().bytes
+            exclude_credentials = []
+
+        options = generate_registration_options(
+            rp_id=app.config["WEBAUTHN_RP_ID"],
+            rp_name=app.config["WEBAUTHN_RP_NAME"],
+            user_id=user_handle,
+            user_name=username,
+            user_display_name=display_name,
+            authenticator_selection=AuthenticatorSelectionCriteria(
+                user_verification=UserVerificationRequirement.REQUIRED,
+                resident_key=ResidentKeyRequirement.PREFERRED,
+            ),
+            attestation="none",
+            exclude_credentials=exclude_credentials,
+        )
+
+        ChallengeSession.store(options.challenge, username, display_name, user_handle)
+        return jsonify(json.loads(options.model_dump_json()))
+
+    @app.route("/register/verify", methods=["POST"])
+    def register_verify():
+        challenge = ChallengeSession.pop_challenge()
+        if not challenge:
+            return jsonify({"error": "チャレンジの有効期限が切れています"}), 400
+        try:
+            credential = RegistrationCredential.parse_raw(request.data)
+            verification = verify_registration_response(
+                credential=credential,
+                expected_challenge=challenge,
+                expected_rp_id=app.config["WEBAUTHN_RP_ID"],
+                expected_origin=app.config["WEBAUTHN_ORIGIN"],
+                require_user_verification=True,
+            )
+        except InvalidRegistrationResponse as exc:
+            ChallengeSession.clear_pending_user()
+            return jsonify({"error": f"登録の検証に失敗しました: {exc}"}), 400
+        except Exception as exc:  # pragma: no cover - 予期しないエラー
+            ChallengeSession.clear_pending_user()
+            return jsonify({"error": f"登録時に予期しないエラーが発生しました: {exc}"}), 400
+
+        username = ChallengeSession.pending_username()
+        display_name = ChallengeSession.pending_display_name()
+        user_handle = ChallengeSession.pending_user_handle()
+
+        if not username or not display_name or not user_handle:
+            return jsonify({"error": "ユーザー情報の取得に失敗しました"}), 400
+
+        user = User.query.filter_by(username=username).first()
+        if not user:
+            user = User(
+                username=username,
+                display_name=display_name,
+                user_handle=user_handle,
+            )
+            db.session.add(user)
+            db.session.flush()
+
+        credential_id = base64.urlsafe_b64encode(verification.credential_id).decode("utf-8")
+        public_key = base64.b64encode(verification.credential_public_key).decode("utf-8")
+        transports = None
+        if credential.response.transports:
+            transports = ",".join(t.value for t in credential.response.transports)
+
+        existing_credential = Credential.query.filter_by(credential_id=credential_id).first()
+        if existing_credential:
+            existing_credential.public_key = public_key
+            existing_credential.sign_count = verification.sign_count
+            existing_credential.transports = transports
+        else:
+            db.session.add(
+                Credential(
+                    credential_id=credential_id,
+                    public_key=public_key,
+                    sign_count=verification.sign_count,
+                    transports=transports,
+                    user=user,
+                )
+            )
+        db.session.commit()
+
+        ChallengeSession.clear_pending_user()
+        session["user_id"] = user.id
+
+        return jsonify({"verified": True})
+
+    @app.route("/login/options", methods=["POST"])
+    def login_options():
+        data = request.get_json(force=True)
+        username = data.get("username", "").strip()
+        if not username:
+            return jsonify({"error": "username は必須です"}), 400
+
+        user = User.query.filter_by(username=username).first()
+        if not user or not user.credentials:
+            return jsonify({"error": "該当するユーザーが見つかりません"}), 404
+
+        allow_credentials = []
+        for cred in user.credentials:
+            transports = (
+                [AuthenticatorTransport(t) for t in cred.transports.split(",")] if cred.transports else None
+            )
+            allow_credentials.append(
+                PublicKeyCredentialDescriptor(
+                    id=base64.urlsafe_b64decode(cred.credential_id.encode("utf-8")),
+                    type="public-key",
+                    transports=transports,
+                )
+            )
+
+        options = generate_authentication_options(
+            rp_id=app.config["WEBAUTHN_RP_ID"],
+            allow_credentials=allow_credentials,
+            user_verification=UserVerificationRequirement.PREFERRED,
+        )
+
+        ChallengeSession.store_authentication(options.challenge)
+        session["login_username"] = username
+
+        return jsonify(json.loads(options.model_dump_json()))
+
+    @app.route("/login/verify", methods=["POST"])
+    def login_verify():
+        challenge = ChallengeSession.pop_challenge()
+        username = session.pop("login_username", None)
+        if not challenge or not username:
+            return jsonify({"error": "チャレンジの有効期限が切れています"}), 400
+
+        user = User.query.filter_by(username=username).first()
+        if not user:
+            return jsonify({"error": "ユーザーが存在しません"}), 400
+
+        try:
+            credential = AuthenticationCredential.parse_raw(request.data)
+            raw_id = base64.urlsafe_b64encode(credential.raw_id).decode("utf-8")
+            stored_credential = next(
+                (cred for cred in user.credentials if cred.credential_id == raw_id),
+                None,
+            )
+            if not stored_credential:
+                return jsonify({"error": "証明書情報が見つかりません"}), 404
+
+            verification = verify_authentication_response(
+                credential=credential,
+                expected_challenge=challenge,
+                expected_rp_id=app.config["WEBAUTHN_RP_ID"],
+                expected_origin=app.config["WEBAUTHN_ORIGIN"],
+                credential_public_key=base64.b64decode(stored_credential.public_key.encode("utf-8")),
+                credential_current_sign_count=stored_credential.sign_count,
+                require_user_verification=True,
+            )
+        except InvalidAuthenticationResponse as exc:
+            return jsonify({"error": f"認証に失敗しました: {exc}"}), 400
+        except Exception as exc:  # pragma: no cover - 予期しないエラー
+            return jsonify({"error": f"認証で予期しないエラーが発生しました: {exc}"}), 400
+
+        stored_credential.sign_count = verification.new_sign_count
+        db.session.commit()
+
+        session["user_id"] = user.id
+
+        return jsonify({"verified": True})
+
+    return app
+
+
+if __name__ == "__main__":
+    application = create_app()
+    application.run(host="0.0.0.0", port=5000, debug=True)

--- a/config.py
+++ b/config.py
@@ -1,0 +1,21 @@
+import os
+from datetime import timedelta
+
+
+class Config:
+    SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret-key")
+    SQLALCHEMY_DATABASE_URI = os.environ.get(
+        "DATABASE_URI",
+        "mysql+pymysql://webauthn:webauthn@localhost:3306/webauthn",
+    )
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SESSION_COOKIE_SECURE = False
+    PERMANENT_SESSION_LIFETIME = timedelta(hours=1)
+    WEBAUTHN_RP_ID = os.environ.get("WEBAUTHN_RP_ID", "localhost")
+    WEBAUTHN_RP_NAME = os.environ.get("WEBAUTHN_RP_NAME", "WebAuthn Demo")
+    WEBAUTHN_ORIGIN = os.environ.get("WEBAUTHN_ORIGIN", "http://localhost:5000")
+
+
+class TestConfig(Config):
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    SESSION_COOKIE_SECURE = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask==3.0.2
+Flask-SQLAlchemy==3.1.1
+PyMySQL==1.1.0
+webauthn==1.10.1
+python-dotenv==1.0.1

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,0 +1,12 @@
+body {
+  min-height: 100vh;
+}
+
+.card {
+  border: none;
+}
+
+#register-message,
+#login-message {
+  min-height: 1.5rem;
+}

--- a/static/js/webauthn.js
+++ b/static/js/webauthn.js
@@ -1,0 +1,78 @@
+function bufferToBase64URLString(buffer) {
+  const bytes = new Uint8Array(buffer);
+  let str = '';
+  bytes.forEach((b) => (str += String.fromCharCode(b)));
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function base64URLStringToBuffer(base64URLString) {
+  const padding = '='.repeat((4 - (base64URLString.length % 4)) % 4);
+  const base64 = (base64URLString + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const str = atob(base64);
+  const buffer = new ArrayBuffer(str.length);
+  const view = new Uint8Array(buffer);
+  for (let i = 0; i < str.length; i += 1) {
+    view[i] = str.charCodeAt(i);
+  }
+  return buffer;
+}
+
+function transformCreateOptions(options) {
+  const publicKey = options.publicKey || options;
+  publicKey.challenge = base64URLStringToBuffer(publicKey.challenge);
+  publicKey.user.id = base64URLStringToBuffer(publicKey.user.id);
+  if (publicKey.excludeCredentials) {
+    publicKey.excludeCredentials = publicKey.excludeCredentials.map((cred) => ({
+      ...cred,
+      id: base64URLStringToBuffer(cred.id),
+    }));
+  }
+  return { publicKey };
+}
+
+function transformRequestOptions(options) {
+  const publicKey = options.publicKey || options;
+  publicKey.challenge = base64URLStringToBuffer(publicKey.challenge);
+  if (publicKey.allowCredentials) {
+    publicKey.allowCredentials = publicKey.allowCredentials.map((cred) => ({
+      ...cred,
+      id: base64URLStringToBuffer(cred.id),
+    }));
+  }
+  return { publicKey };
+}
+
+function serializeRegistration(credential) {
+  const transports = credential.response.getTransports ? credential.response.getTransports() : [];
+  return {
+    id: credential.id,
+    rawId: bufferToBase64URLString(credential.rawId),
+    type: credential.type,
+    response: {
+      attestationObject: bufferToBase64URLString(credential.response.attestationObject),
+      clientDataJSON: bufferToBase64URLString(credential.response.clientDataJSON),
+      transports,
+    },
+  };
+}
+
+function serializeAuthentication(assertion) {
+  return {
+    id: assertion.id,
+    rawId: bufferToBase64URLString(assertion.rawId),
+    type: assertion.type,
+    response: {
+      authenticatorData: bufferToBase64URLString(assertion.response.authenticatorData),
+      clientDataJSON: bufferToBase64URLString(assertion.response.clientDataJSON),
+      signature: bufferToBase64URLString(assertion.response.signature),
+      userHandle: assertion.response.userHandle
+        ? bufferToBase64URLString(assertion.response.userHandle)
+        : null,
+    },
+  };
+}
+
+window.transformCreateOptions = transformCreateOptions;
+window.transformRequestOptions = transformRequestOptions;
+window.serializeRegistration = serializeRegistration;
+window.serializeAuthentication = serializeAuthentication;

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}WebAuthn Demo{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+  </head>
+  <body class="bg-light">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('index') }}">WebAuthn Demo</a>
+        <div>
+          {% if session.get('user_id') %}
+          <a class="btn btn-outline-light" href="{{ url_for('logout') }}">ログアウト</a>
+          {% endif %}
+        </div>
+      </div>
+    </nav>
+    <main class="container py-5">
+      {% block content %}{% endblock %}
+    </main>
+    <script src="https://cdn.jsdelivr.net/npm/axios@1.6.7/dist/axios.min.js" integrity="sha384-pTS5fV2Z6kGgREjA5Xjq5ygXSubn5s0gxq/F1b8Wz8tPh7HsqaDU8StGIC2xLquH" crossorigin="anonymous"></script>
+    <script src="{{ url_for('static', filename='js/webauthn.js') }}"></script>
+    {% block scripts %}{% endblock %}
+  </body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block title %}ダッシュボード | WebAuthn Demo{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-8">
+    <div class="card shadow-sm">
+      <div class="card-body">
+        <h2 class="card-title h4">ようこそ {{ user.display_name }} さん</h2>
+        <p class="text-muted">FIDO2 によるパスワードレス認証が完了しました。</p>
+        <p class="mb-0">登録済みの認証器数: <strong>{{ user.credentials|length }}</strong></p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,48 @@
+{% extends 'base.html' %}
+{% block title %}ログイン | WebAuthn Demo{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-6">
+    <div class="card shadow-sm">
+      <div class="card-body">
+        <h2 class="card-title h4 mb-4">パスワードレスログイン</h2>
+        <div class="mb-3">
+          <label class="form-label" for="login-username">ユーザー名</label>
+          <input id="login-username" type="text" class="form-control" placeholder="例: yamada" autocomplete="username">
+        </div>
+        <div class="d-grid gap-2">
+          <button id="login-button" class="btn btn-primary">FIDO2 でログイン</button>
+          <a href="{{ url_for('register_page') }}" class="btn btn-outline-secondary">新規登録はこちら</a>
+        </div>
+        <div id="login-message" class="mt-3 text-danger"></div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<script>
+  document.getElementById('login-button').addEventListener('click', async () => {
+    const username = document.getElementById('login-username').value.trim();
+    const messageEl = document.getElementById('login-message');
+    messageEl.textContent = '';
+    if (!username) {
+      messageEl.textContent = 'ユーザー名を入力してください';
+      return;
+    }
+    try {
+      const optionsResponse = await axios.post('/login/options', { username });
+      const options = transformRequestOptions(optionsResponse.data);
+      const assertion = await navigator.credentials.get(options);
+      const payload = serializeAuthentication(assertion);
+      const verifyResponse = await axios.post('/login/verify', payload, { headers: { 'Content-Type': 'application/json' } });
+      if (verifyResponse.data.verified) {
+        window.location.href = '{{ url_for('dashboard') }}';
+      }
+    } catch (error) {
+      console.error(error);
+      messageEl.textContent = error.response?.data?.error || '認証に失敗しました。ブラウザが WebAuthn に対応しているか確認してください。';
+    }
+  });
+</script>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,53 @@
+{% extends 'base.html' %}
+{% block title %}登録 | WebAuthn Demo{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-6">
+    <div class="card shadow-sm">
+      <div class="card-body">
+        <h2 class="card-title h4 mb-4">セキュアな FIDO2 認証を登録</h2>
+        <div class="mb-3">
+          <label class="form-label" for="register-username">ユーザー名</label>
+          <input id="register-username" type="text" class="form-control" placeholder="例: yamada" autocomplete="username">
+        </div>
+        <div class="mb-3">
+          <label class="form-label" for="register-display-name">表示名</label>
+          <input id="register-display-name" type="text" class="form-control" placeholder="例: 山田太郎" autocomplete="name">
+        </div>
+        <div class="d-grid gap-2">
+          <button id="register-button" class="btn btn-success">セキュリティキーを登録</button>
+          <a href="{{ url_for('login_page') }}" class="btn btn-outline-secondary">すでにアカウントをお持ちの方はこちら</a>
+        </div>
+        <div id="register-message" class="mt-3 text-danger"></div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<script>
+  document.getElementById('register-button').addEventListener('click', async () => {
+    const username = document.getElementById('register-username').value.trim();
+    const displayName = document.getElementById('register-display-name').value.trim();
+    const messageEl = document.getElementById('register-message');
+    messageEl.textContent = '';
+    if (!username || !displayName) {
+      messageEl.textContent = 'ユーザー名と表示名を入力してください';
+      return;
+    }
+    try {
+      const optionsResponse = await axios.post('/register/options', { username, displayName });
+      const options = transformCreateOptions(optionsResponse.data);
+      const credential = await navigator.credentials.create(options);
+      const payload = serializeRegistration(credential, { username, displayName });
+      const verifyResponse = await axios.post('/register/verify', payload, { headers: { 'Content-Type': 'application/json' } });
+      if (verifyResponse.data.verified) {
+        window.location.href = '{{ url_for('dashboard') }}';
+      }
+    } catch (error) {
+      console.error(error);
+      messageEl.textContent = error.response?.data?.error || '登録に失敗しました。ブラウザが WebAuthn に対応しているか確認してください。';
+    }
+  });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement a Flask application that supports WebAuthn-based registration and authentication backed by MySQL
- add Bootstrap-powered templates and client-side JavaScript to drive WebAuthn registration and login flows
- document setup steps and dependencies for running the demo locally

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68de18ffd0488326ba1ecd79762ab2d4